### PR TITLE
Gb 54 работа с eureka

### DIFF
--- a/cart-service/src/main/java/ru/nhp/cart/integrations/ProductsServiceIntegration.java
+++ b/cart-service/src/main/java/ru/nhp/cart/integrations/ProductsServiceIntegration.java
@@ -1,19 +1,27 @@
 package ru.nhp.cart.integrations;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import ru.nhp.api.dto.core.ProductDto;
+import ru.nhp.cart.properties.CoreServiceIntegrationProperties;
 
 import java.util.Optional;
 
 @Component
+@EnableConfigurationProperties({
+        CoreServiceIntegrationProperties.class,
+})
 @RequiredArgsConstructor
 public class ProductsServiceIntegration {
-    private final WebClient webClient;
+    private final WebClient.Builder webClient;
+    private final CoreServiceIntegrationProperties coreServiceIntegrationProperties;
 
     public Optional<ProductDto> findById(Long id) {
         ProductDto productDto = webClient
+                .baseUrl(coreServiceIntegrationProperties.getUrl())
+                .build()
                 .get()
                 .uri("/api/v1/products/" + id)
                 .retrieve()

--- a/cart-service/src/main/java/ru/nhp/cart/properties/CoreServiceIntegrationProperties.java
+++ b/cart-service/src/main/java/ru/nhp/cart/properties/CoreServiceIntegrationProperties.java
@@ -13,5 +13,6 @@ public class CoreServiceIntegrationProperties {
     private Integer connectTimeout;
     private Integer readTimeout;
     private Integer writeTimeout;
+    private Integer responseTimeout;
     private String url;
 }

--- a/cart-service/src/main/resources/application.yaml
+++ b/cart-service/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ integrations:
 #    connect-timeout: 2000
 #    read-timeout: 10000
 #    write-timeout: 2000
-    url: lb://gateway:5555/core  #   имя приложения в eureka
+    url: lb://core-service  #   имя приложения в eureka
 eureka:
   instance:
     prefer-ip-address: true

--- a/cart-service/src/main/resources/application.yaml
+++ b/cart-service/src/main/resources/application.yaml
@@ -6,14 +6,12 @@ utils:
   cart:
     prefix: SPRING_WEB_APP_
 integrations:
-  core-service:           #TODO надо определиться с параметрами таймаутов
-    connect-timeout: 1000 #TODO в коде до введения класса свойств была константа TIMEOUT = 1000
-    read-timeout: 1000    #TODO она стояла для всех трех таймаутов одинаковой
-    write-timeout: 1000   #TODO поэтому появились эти три строки вместе ниже закомментированных
-#    connect-timeout: 2000
-#    read-timeout: 10000
-#    write-timeout: 2000
-    url: lb://core-service  #   имя приложения в eureka
+  core-service:
+    connect-timeout: 1000
+    read-timeout: 1000
+    write-timeout: 1000
+    response-timeout: 1000
+    url: lb://core-service/web-market-core  #   имя приложения в eureka
 eureka:
   instance:
     prefer-ip-address: true

--- a/cart-service/src/main/resources/application.yaml
+++ b/cart-service/src/main/resources/application.yaml
@@ -15,11 +15,14 @@ integrations:
 eureka:
   instance:
     prefer-ip-address: true
+    lease-renewal-interval-in-seconds: 5   # интервал сигналов на сервер eureka
+    lease-expiration-duration-in-seconds: 10 # таймер "down" после последнего сигнала
   client:
     service-url:
       defaultZone: ${EUREKA_URI:http://eureka:8761/eureka/}
     registerWithEureka: true
     fetchRegistry: true
+    registry-fetch-interval-seconds: 5 #  интервал извлечения информации о регистрации сервисов
 spring:
   application:
     name: cart-service

--- a/core-service/src/main/java/ru/nhp/core/configs/WebClientConfig.java
+++ b/core-service/src/main/java/ru/nhp/core/configs/WebClientConfig.java
@@ -26,7 +26,10 @@ public class WebClientConfig {
 
     @Bean
     @LoadBalanced
-    public WebClient cartServiceWebClient() {
+    public WebClient.Builder cartServiceWebClient() {
+
+        // WebClient работает с eureka только если bean возвращает builder
+
         HttpClient httpClient = reactor.netty.http.client.HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, cartServiceIntegrationProperties.getConnectTimeout())
                 .responseTimeout(Duration.ofMillis(cartServiceIntegrationProperties.getConnectTimeout()))
@@ -34,8 +37,6 @@ public class WebClientConfig {
                         conn.addHandlerLast(new ReadTimeoutHandler(cartServiceIntegrationProperties.getConnectTimeout(), TimeUnit.MILLISECONDS))
                                 .addHandlerLast(new WriteTimeoutHandler(cartServiceIntegrationProperties.getConnectTimeout(), TimeUnit.MILLISECONDS)));
         return WebClient.builder()
-                .baseUrl(cartServiceIntegrationProperties.getUrl())
-                .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .build();
+                .clientConnector(new ReactorClientHttpConnector(httpClient));
     }
 }

--- a/core-service/src/main/java/ru/nhp/core/exceptions/CoreAppError.java
+++ b/core-service/src/main/java/ru/nhp/core/exceptions/CoreAppError.java
@@ -3,6 +3,7 @@ package ru.nhp.core.exceptions;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.validation.ObjectError;
 import ru.nhp.api.exceptions.AppError;
 
@@ -10,12 +11,13 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 @Schema(description = "Ошибки основного сервиса")
 public class CoreAppError extends AppError {
     @Schema(description = "Коды ошибок сервиса", example = "PRODUCT_NOT_FOUND")
-    private final Enum<?> code;
+    private Enum<?> code;
     @Schema(description = "Сообщения ошибок сервиса", example = "Продукт не найден")
-    private final String message;
+    private String message;
     @Schema(description = "Список ошибок валидации", example = "Поле названия товара не должно быть пустым")
     private List<ObjectError> errors;
 

--- a/core-service/src/main/java/ru/nhp/core/integrations/CartServiceIntegration.java
+++ b/core-service/src/main/java/ru/nhp/core/integrations/CartServiceIntegration.java
@@ -2,20 +2,26 @@ package ru.nhp.core.integrations;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import ru.nhp.api.dto.cart.CartDto;
 import ru.nhp.core.exceptions.CartServiceIntegrationException;
 import ru.nhp.core.exceptions.CoreAppError;
+import ru.nhp.core.properties.CartServiceIntegrationProperties;
 
 @Slf4j
 @Component
+@EnableConfigurationProperties(
+        CartServiceIntegrationProperties.class
+)
 @RequiredArgsConstructor
 public class CartServiceIntegration {
     private final static String CLEAR_USER_CART_URI = "/api/v1/cart/0/clear";
     private final static String GET_USER_CART_URI = "/api/v1/cart/0";
-    private final WebClient webClient;
+    private final WebClient.Builder webClient;
+    private final CartServiceIntegrationProperties cartServiceIntegrationProperties;
 
     public void clearUserCart(String username) {
         getOnStatus(CLEAR_USER_CART_URI, username)
@@ -30,7 +36,10 @@ public class CartServiceIntegration {
     }
 
     private WebClient.ResponseSpec getOnStatus(String uri, String username) {
-        return webClient.get()
+        return webClient
+                .baseUrl(cartServiceIntegrationProperties.getUrl())
+                .build()
+                .get()
                 .uri(uri)
                 .header("username", username)
                 .retrieve()

--- a/core-service/src/main/java/ru/nhp/core/integrations/CartServiceIntegration.java
+++ b/core-service/src/main/java/ru/nhp/core/integrations/CartServiceIntegration.java
@@ -18,8 +18,8 @@ import ru.nhp.core.properties.CartServiceIntegrationProperties;
 )
 @RequiredArgsConstructor
 public class CartServiceIntegration {
-    private final static String CLEAR_USER_CART_URI = "/api/v1/cart/0/clear";
-    private final static String GET_USER_CART_URI = "/api/v1/cart/0";
+    private final static String CLEAR_USER_CART_URI = "/api/v1/carts/0/clear";
+    private final static String GET_USER_CART_URI = "/api/v1/carts/0";
     private final WebClient.Builder webClient;
     private final CartServiceIntegrationProperties cartServiceIntegrationProperties;
 

--- a/core-service/src/main/resources/application.yaml
+++ b/core-service/src/main/resources/application.yaml
@@ -28,8 +28,13 @@ integrations:
 eureka:
   instance:
     prefer-ip-address: true
+    lease-renewal-interval-in-seconds: 5   # интервал сигналов на сервер eureka
+    lease-expiration-duration-in-seconds: 10 # таймер "down" после последнего сигнала
   client:
     service-url:
       defaultZone: ${EUREKA_URI:http://eureka:8761/eureka/}
     registerWithEureka: true
     fetchRegistry: true
+    health-check:
+      enabled: true
+    registry-fetch-interval-seconds: 5 #  интервал извлечения информации о регистрации сервисов

--- a/core-service/src/main/resources/application.yaml
+++ b/core-service/src/main/resources/application.yaml
@@ -21,7 +21,7 @@ logging:
     org.hibernate: INFO
 integrations:
   cart-service:
-    url: lb://gateway:5555/cart  #  имя контейнера в eureka
+    url: lb://cart-service  #  имя контейнера в eureka
     connect-timeout: 2000
     read-timeout: 10000
     write-timeout: 2000

--- a/core-service/src/main/resources/application.yaml
+++ b/core-service/src/main/resources/application.yaml
@@ -21,7 +21,7 @@ logging:
     org.hibernate: INFO
 integrations:
   cart-service:
-    url: lb://cart-service  #  имя контейнера в eureka
+    url: lb://cart-service/web-market-cart  #  имя приложения в eureka
     connect-timeout: 2000
     read-timeout: 10000
     write-timeout: 2000

--- a/eureka-service/pom.xml
+++ b/eureka-service/pom.xml
@@ -22,16 +22,6 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/eureka-service/src/main/resources/application.yaml
+++ b/eureka-service/src/main/resources/application.yaml
@@ -7,6 +7,8 @@ eureka:
     register-with-eureka: false
     fetch-registry: false
   server:
+    enable-self-preservation: false # отключение самозащиты для игнора сетевых сбоев
+    eviction-interval-timer-in-ms: 5000 # время очистки сервера
     waitTimeInMsWhenSyncEmpty: 0  # когда сервер eureka запускается,
                                   # можно не ждать информацию о регистрации экземпляра
 spring:

--- a/eureka-service/src/main/resources/application.yaml
+++ b/eureka-service/src/main/resources/application.yaml
@@ -7,7 +7,8 @@ eureka:
     register-with-eureka: false
     fetch-registry: false
   server:
-    waitTimeInMsWhenSyncEmpty: 0
+    waitTimeInMsWhenSyncEmpty: 0  # когда сервер eureka запускается,
+                                  # можно не ждать информацию о регистрации экземпляра
 spring:
   application:
     name: eureka-service

--- a/front-service/src/main/resources/application.yaml
+++ b/front-service/src/main/resources/application.yaml
@@ -3,10 +3,15 @@ server:
   servlet:
     context-path: /front
 eureka:
+  instance:
+    prefer-ip-address: true
+    lease-renewal-interval-in-seconds: 5   # интервал сигналов на сервер eureka
+    lease-expiration-duration-in-seconds: 10 # таймер "down" после последнего сигнала
   client:
     service-url:
       defaultZone: ${EUREKA_URI:http://eureka:8761/eureka/}
-    fetch-registry: false
+    registerWithEureka: true
+    fetchRegistry: true
 spring:
   application:
     name: front-service

--- a/gateway-service/src/main/java/ru/nhp/gateway/JwtAuthFilter.java
+++ b/gateway-service/src/main/java/ru/nhp/gateway/JwtAuthFilter.java
@@ -23,14 +23,14 @@ public class JwtAuthFilter extends AbstractGatewayFilterFactory<JwtAuthFilter.Co
     @Override
     public GatewayFilter apply(Config config) {
         return (exchange, chain) -> {
-//            ServerHttpRequest request = exchange.getRequest();
-//            if (isAuthOk(request)) {
-//                final String token = getAuthHeader(request);
-//                if (jwtUtil.isInvalid(token)) {
-//                    return this.onError(exchange, "Authorization header is invalid", HttpStatus.UNAUTHORIZED);
-//                }
-//                populateRequestWithHeaders(exchange, token);
-//            }
+            ServerHttpRequest request = exchange.getRequest();
+            if (isAuthOk(request)) {
+                final String token = getAuthHeader(request);
+                if (jwtUtil.isInvalid(token)) {
+                    return this.onError(exchange, "Authorization header is invalid", HttpStatus.UNAUTHORIZED);
+                }
+                populateRequestWithHeaders(exchange, token);
+            }
             return chain.filter(exchange);
         };
     }
@@ -49,8 +49,8 @@ public class JwtAuthFilter extends AbstractGatewayFilterFactory<JwtAuthFilter.Co
     }
 
     private boolean isAuthOk(ServerHttpRequest request) {
-        if (request.getHeaders().containsKey("Authorization")) {
-            return true;
+        if (! request.getHeaders().containsKey("Authorization")) {
+            return false;
         }
         return request.getHeaders().getOrEmpty("Authorization").get(0).startsWith("Bearer ");
     }

--- a/gateway-service/src/main/resources/application.yaml
+++ b/gateway-service/src/main/resources/application.yaml
@@ -48,6 +48,8 @@ jwt:
 eureka:
   instance:
     prefer-ip-address: true
+    lease-renewal-interval-in-seconds: 5   # интервал сигналов на сервер eureka
+    lease-expiration-duration-in-seconds: 10 # таймер "down" после последнего сигнала
   client:
     service-url:
       defaultZone: ${EUREKA_URI:http://eureka:8761/eureka/}

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>

--- a/user-service/src/main/java/user/eureka/UserHealthCheckHandler.java
+++ b/user-service/src/main/java/user/eureka/UserHealthCheckHandler.java
@@ -1,0 +1,23 @@
+package user.eureka;
+
+import com.netflix.appinfo.HealthCheckHandler;
+import com.netflix.appinfo.InstanceInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserHealthCheckHandler implements HealthCheckHandler {
+    private final UserHealthIndicator userHealthIndicator;
+
+    @Override
+    public InstanceInfo.InstanceStatus getStatus(InstanceInfo.InstanceStatus instanceStatus) {
+        Status status = userHealthIndicator.health().getStatus();
+        if (status.equals(Status.UP)) {
+            return InstanceInfo.InstanceStatus.UP;
+        } else {
+            return InstanceInfo.InstanceStatus.DOWN;
+        }
+    }
+}

--- a/user-service/src/main/java/user/eureka/UserHealthIndicator.java
+++ b/user-service/src/main/java/user/eureka/UserHealthIndicator.java
@@ -1,0 +1,33 @@
+package user.eureka;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Component;
+import user.repositories.UserRepository;
+
+@Component
+@RequiredArgsConstructor
+public class UserHealthIndicator implements HealthIndicator {
+    private final UserRepository userRepository;
+
+    @Override
+    public Health health() {
+        if (checkDB()) {
+            return new Health.Builder(Status.UP).build();
+        } else {
+            return new Health.Builder(Status.DOWN).build();
+        }
+    }
+
+    private Boolean checkDB() {
+        try {
+            userRepository.count();
+        } catch (Exception exception) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/user-service/src/main/resources/application.yaml
+++ b/user-service/src/main/resources/application.yaml
@@ -38,7 +38,15 @@ jwt:
   lifetime: 36000000
 
 eureka:
+  instance:
+    prefer-ip-address: true
+    lease-renewal-interval-in-seconds: 5   # интервал сигналов на сервер eureka
+    lease-expiration-duration-in-seconds: 10 # таймер "down" после последнего сигнала
   client:
     service-url:
       defaultZone: ${EUREKA_URI:http://eureka:8761/eureka/}
-    fetch-registry: false
+    registerWithEureka: true
+    fetchRegistry: true
+    health-check:
+      enabled: true
+    registry-fetch-interval-seconds: 5 #  интервал извлечения информации о регистрации сервисов


### PR DESCRIPTION
1. Провести исследование и определить нужна ли эврика во front-service.
    
Логики во front-service не заложено и другие сервисы к нему не обращаются, но front-service это запускаемое приложение и с помощью eureka удобно отслеживать его состояние. К тому же, если в будущем будем затрагивать вопрос масштабирования сервисов, то и для front-service может понадобиться несколько экземпляров. Хотя я это пока слабо себе представляю. Поэтому решил пока оставить front-service в eureka.

2. Нужны ли классы ProductHealthCheckHandler и ProductHealthIndicator.

С помощью этих классов сервис сам может управлять своим статусом в eureka. Если в сервисе, например, упала БД, то для eureka он по-прежнему "в строю", а для других сервисов он уже не функционален. И в этом случае сервис сам меняет свой статус на "Down", а когда соединение с БД восстанавливается он сам меняет свой статус в eureka на "Up".
В качестве параметра для изменения статуса может выступать любой функционал, не только БД.
Поэтому похожие классы я добавил в user-service и, когда будет добавлен redis в cart-service, то и туда добавлю что-то похожее.

3. Настроить эврику, что бы она принимала только имя приложения, без указания порта.

Теперь сервисы общаются в соответствие со схемой выложенной на Miro. Всё работает через докер.