### PR TITLE
Gb 64 создать каркас config server

### DIFF
--- a/config-service/Dockerfile
+++ b/config-service/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17
+ARG JAR_FILE=config-service/target/config-service-0.0.1-exec.jar
+COPY ${JAR_FILE} config.jar
+ENTRYPOINT ["java", "-jar", "/config.jar"]

--- a/config-service/pom.xml
+++ b/config-service/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>ru.market-gb</groupId>
     <artifactId>config-service</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1</version>
     <name>config-service</name>
     <description>Config-service for graduation-project</description>
     <properties>
@@ -53,6 +53,14 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <configuration>
+                            <classifier>exec</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/config-service/pom.xml
+++ b/config-service/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.1</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>ru.market-gb</groupId>
+    <artifactId>config-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>config-service</name>
+    <description>Config-service for graduation-project</description>
+    <properties>
+        <java.version>17</java.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-config-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/config-service/src/main/java/ru/nhp/config/ConfigServiceApplication.java
+++ b/config-service/src/main/java/ru/nhp/config/ConfigServiceApplication.java
@@ -3,9 +3,11 @@ package ru.nhp.config;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.config.server.EnableConfigServer;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 
 @SpringBootApplication
 @EnableConfigServer
+@EnableEurekaClient
 public class ConfigServiceApplication {
 
     public static void main(String[] args) {

--- a/config-service/src/main/java/ru/nhp/config/ConfigServiceApplication.java
+++ b/config-service/src/main/java/ru/nhp/config/ConfigServiceApplication.java
@@ -1,0 +1,15 @@
+package ru.nhp.config;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+@SpringBootApplication
+@EnableConfigServer
+public class ConfigServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ConfigServiceApplication.class, args);
+    }
+
+}

--- a/config-service/src/main/resources/application.yaml
+++ b/config-service/src/main/resources/application.yaml
@@ -20,9 +20,8 @@ spring:
           clone-on-start: true   # при старте config-service из репозитория подтягиваются изменения
           username: ${GIT_USERNAME:NHP22}  # имя репозитория
           password: ${GIT_PASSWORD:NhP_2022}  # пароль репозитроия
-        default-label: main  # ветка в репозитории
-
-
+        default-label: main  # ветка в репозитории по умолчанию
+        default-profile: dev # профиль по умолчанию
 
         # localhost:8888/{application_name}/{profile}/{label}
         # localhost:8888/core-service/dev/main

--- a/config-service/src/main/resources/application.yaml
+++ b/config-service/src/main/resources/application.yaml
@@ -24,6 +24,3 @@ spring:
           password: ${GIT_PASSWORD:NhP_2022}  # пароль репозитория
         default-label: main  # ветка в репозитории по умолчанию
         default-profile: dev # профиль по умолчанию
-
-        # localhost:8888/{application_name}/{profile}/{label}
-        # localhost:8888/core-service/dev/main

--- a/config-service/src/main/resources/application.yaml
+++ b/config-service/src/main/resources/application.yaml
@@ -1,0 +1,28 @@
+server:
+  port: ${PORT:8888}
+eureka:
+  instance:
+    prefer-ip-address: true
+  client:
+    service-url:
+      defaultZone: ${EUREKA_URI:http://eureka:8761/eureka/}
+    registerWithEureka: true
+    fetchRegistry: true
+spring:
+  application:
+    name: config-service
+  cloud:
+    config:
+      server:
+        git:
+          uri: ${GIT_URI:https://github.com/NHP22/nhp-settings}
+          search-paths: ${GIT_SEARCH_PATHS:/nhp-configs}  # путь внутри репозитория
+          clone-on-start: true   # при старте config-service из репозитория подтягиваются изменения
+          username: ${GIT_USERNAME:NHP22}  # имя репозитория
+          password: ${GIT_PASSWORD:NhP_2022}  # пароль репозитроия
+        default-label: main  # ветка в репозитории
+
+
+
+        # localhost:8888/{application_name}/{profile}/{label}
+        # localhost:8888/core-service/dev/main

--- a/config-service/src/main/resources/application.yaml
+++ b/config-service/src/main/resources/application.yaml
@@ -13,13 +13,15 @@ spring:
     name: config-service
   cloud:
     config:
+      discovery:
+        enabled: true
       server:
         git:
           uri: ${GIT_URI:https://github.com/NHP22/nhp-settings}
           search-paths: ${GIT_SEARCH_PATHS:/nhp-configs}  # путь внутри репозитория
           clone-on-start: true   # при старте config-service из репозитория подтягиваются изменения
           username: ${GIT_USERNAME:NHP22}  # имя репозитория
-          password: ${GIT_PASSWORD:NhP_2022}  # пароль репозитроия
+          password: ${GIT_PASSWORD:NhP_2022}  # пароль репозитория
         default-label: main  # ветка в репозитории по умолчанию
         default-profile: dev # профиль по умолчанию
 

--- a/core-service/pom.xml
+++ b/core-service/pom.xml
@@ -24,6 +24,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>

--- a/core-service/src/main/resources/application.yaml
+++ b/core-service/src/main/resources/application.yaml
@@ -1,41 +1,14 @@
-server:
-  port: 8000
-  servlet:
-    context-path: /web-market-core
-spring:
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    username: postgres
-    password: postgres
-    url: jdbc:postgresql://localhost:5430/beta
-  jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-  application:
-    name: core-service
-logging:
-  level:
-    root: INFO
-    org.springframework.web: INFO
-    org.hibernate: INFO
-integrations:
-  cart-service:
-    url: lb://cart-service/web-market-cart  #  имя приложения в eureka
-    connect-timeout: 1000
-    read-timeout: 1000
-    write-timeout: 1000
-    response-timeout: 1000
 eureka:
-  instance:
-    prefer-ip-address: true
-    lease-renewal-interval-in-seconds: 5   # интервал сигналов на сервер eureka
-    lease-expiration-duration-in-seconds: 10 # таймер "down" после последнего сигнала
   client:
     service-url:
       defaultZone: ${EUREKA_URI:http://eureka:8761/eureka/}
-    registerWithEureka: true
-    fetchRegistry: true
-    health-check:
-      enabled: true
-    registry-fetch-interval-seconds: 5 #  интервал извлечения информации о регистрации сервисов
+spring:
+  config:
+    import: optional:configserver:lb://config-service
+  application:
+    name: core-service
+  cloud:
+    config:
+      discovery:
+        enabled: true
+        service-id: config-service

--- a/core-service/src/test/resources/application.yaml
+++ b/core-service/src/test/resources/application.yaml
@@ -11,3 +11,6 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+  cloud:
+    config:
+      enabled: false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
             - flyway
         networks:
             - gb-net
-            -
+
     spring_config:
         container_name: config
         build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,6 +67,16 @@ services:
             - flyway
         networks:
             - gb-net
+            -
+    spring_config:
+        container_name: config
+        build:
+            context: .
+            dockerfile: ./config-service/Dockerfile
+        ports:
+            - 8888:8888
+        networks:
+            - gb-net
 
     spring_cart:
         container_name: cart

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>front-service</module>
         <module>user-service</module>
         <module>eureka-service</module>
+        <module>config-service</module>
     </modules>
 
     <parent>


### PR DESCRIPTION
Настройки расположены в GitHub репозитории. Адрес и пароль в config-service/src/main/resources/application.yaml.
Пока там только одна ветка main, она же прописана как дефолтная в config-service/src/main/resources/application.yaml.
Настройки могут подразделяться по веткам, профилям и приложениям.
Путь опроса настроек config-service-ом: сначала смотрит общие настройки, затем - настройки профиля, если они отличаются, то отличия применятся, затем настройки приложения,если они отличаются, то отличия применятся. Таким образом наивысший приоритет у настроек приложения.
В application.yaml приложения можно указать общий путь к config-service (по умолчанию: localhost:8888) и тогда будут применяться профиль и ветка по-умолчанию (из настроек config-service), и applicatio.name из настроек приложения. Можно также конкретизировать путь к настройкам: localhost:8888/{application_name}/{profile}/{label}, например: localhost:8888/core-service/dev/main.
В GitHub репозиторий перенесены часть настроек из core-service. При чём в application.yaml перенесены более общие настройки, которые могут применяться ко всему проекту, а в core-service.yaml перенесены настройки относящиеся конкретно к сервису.
Проверялось через docker и браузер. Всё работает, включая merge корзин при входе и создание заказа. 